### PR TITLE
modified:   Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = ["Guillaume Jeanne"]
 
 [dependencies]
-memmap = "*"
+memmap = "0.5.2"
 rustc-serialize = "*"
 docopt = "*"
 fs2 = "*"


### PR DESCRIPTION
Force the memmap version. The Binacle code does not support memmap 0.6.X